### PR TITLE
Fix issue with some timestamps description

### DIFF
--- a/src/Ethereal.Application/Extensions/StringExtensions.cs
+++ b/src/Ethereal.Application/Extensions/StringExtensions.cs
@@ -1,30 +1,35 @@
-﻿using System;
+using System;
 using System.IO;
 using System.Linq;
 using System.Text;
+using System.Text.RegularExpressions;
 
 namespace Ethereal.Application.Extensions;
 
 public static class StringExtensions
 {
-    public static bool ContainsTimespan(this string str, out TimeSpan timespan)
-    {
-        var parts = str.Split();
+	public static bool ContainsTimespan(this string str, out TimeSpan timespan)
+	{
+		var parts = str.Split();
 
-        foreach (var part in parts)
-        {
-            var cleaned = new string(part.Where(ch => char.IsDigit(ch) || ch == ':').ToArray());
+		foreach (var part in parts)
+		{
+			// Add a regular expression that matches a timestamp preceded by a number and a period, with or without a space
+			var regex = new Regex(@"(\d+\.\s*)?(\d{1,2}:\d{2}(:\d{2})?)");
+			var match = regex.Match(part);
 
-            if (cleaned.Contains(":") == false && cleaned.Length < 3)
-                continue;
+			if (match.Success)
+			{
+				var cleaned = match.Groups[2].Value;  // The second group in the regex is the timestamp
 
-            if (cleaned.TryParseToTimeSpan(out timespan))
-                return true;
-        }
+				if (cleaned.TryParseToTimeSpan(out timespan))
+					return true;
+			}
+		}
 
-        timespan = TimeSpan.MaxValue;
-        return false;
-    }
+		timespan = TimeSpan.MaxValue;
+		return false;
+	}
 
     public static string RemoveTimespan(this string str)
     {
@@ -38,9 +43,10 @@ public static class StringExtensions
         return stringBuilder.ToString().Trim();
     }
 
-    public static string RemoveIllegalCharacters(this string str)
-    {
-        var invalid = new string(Path.GetInvalidFileNameChars()) + new string(Path.GetInvalidPathChars()) + "\"";
-        return invalid.Aggregate(str, (current, c) => current.Replace(c.ToString(), string.Empty));
-    }
+	public static string RemoveIllegalCharacters(this string str)
+	{
+		var invalid = new string(Path.GetInvalidFileNameChars()) + new string(Path.GetInvalidPathChars()) + "\"~|";
+		return invalid.Aggregate(str, (current, c) => current.Replace(c.ToString(), string.Empty));
+	}
+
 }


### PR DESCRIPTION
Making chapters wouldn't work on some videos (https://www.youtube.com/watch?v=FmA6U5rXl38)
Using regular expressions seems to increase split success by not using irrelevant strings (example, Bitcoin appearing here too https://www.youtube.com/watch?v=FmA6U5rXl38)

Everything else seems to work normally.

Also added tilt and pipe as illegal characters.

![image](https://github.com/bubuntoid/Ethereal/assets/114953576/bc36ad3f-4e26-4d27-a096-98e0cce343e8)

